### PR TITLE
Bugfix: Scripts without variables section in the header now work

### DIFF
--- a/src/executer.py
+++ b/src/executer.py
@@ -159,7 +159,8 @@ class Executer:
             print("Error: No script data")
             return
         self.executionSpeed = self.scriptData['speed']
-        self.variableData = self.scriptData['variables']
+        if 'variables' in self.scriptData:
+            self.variableData = self.scriptData['variables']
 
         # Execute the script
         for step in self.scriptData['steps']:


### PR DESCRIPTION
Bugfix: Scripts without variables section in the header now no longer crash