### PR TITLE
fixed execute -f

### DIFF
--- a/src/executionServer.py
+++ b/src/executionServer.py
@@ -57,7 +57,7 @@ async def processInstruction(scriptName: str, *, writer: asyncio.StreamWriter, f
         None
     """
     # Find the script
-    if file == 'True':
+    if file is True:
         scriptPath = scriptName
     else:
         scriptPath = findScript(scriptName)


### PR DESCRIPTION
filepaths now work again when using together with the execute command